### PR TITLE
Come to supporting SM-G9009W fully (Make it connect to CDMA cell properly)

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 Copyright 2015 - The CyanogenMod Project
 
-Device configuration for Samsung Galaxy S 5 China Dual SIMs(SM-G9006W and SM-G9008W).
+Device configuration for Samsung Galaxy S 5 China Dual SIMs(SM-G9006W , SM-G9008W and SM-G9009W).
 
 WORK IN PROGRESS. WILL EAT YOUR CAT.

--- a/README
+++ b/README
@@ -2,4 +2,8 @@ Copyright 2015 - The CyanogenMod Project
 
 Device configuration for Samsung Galaxy S 5 China Dual SIMs(SM-G9006W , SM-G9008W and SM-G9009W).
 
+NOTICE:
+By all means, this device configuration supports these three China models of Galaxy S5. However, without a proper config of RIL allowcation, SM-G9009W had been kept out for a long time.
+Now this problem will be solved. If you have a SM-G9009W by chance, why not give it a shot?
+
 WORK IN PROGRESS. WILL EAT YOUR CAT.

--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -24,5 +24,5 @@
          Empty is viewed as "all".  Only used on devices which
          don't support RIL_REQUEST_GET_RADIO_CAPABILITY
          format is UMTS|LTE|... -->
-    <string translatable="false" name="config_radio_access_family">GSM|TD_SCDMA|WCDMA|LTE</string>
+    <string translatable="false" name="config_radio_access_family">CDMA|EVDO|GSM|TD_SCDMA|WCDMA|LTE</string>
 </resources>


### PR DESCRIPTION
I used to install CM13 for kltechnduo into my SM-G9009W. However, due to **UNPROPER NETWORK CONFIGURATION**(See folder "overlay"), even though my IMEI and baseband infomation can be recognized, it still cannot connect to CDMA cell network.
So, here, please allow me to share my surprising solution here. After modifying the configuration XML file in the "overlay" dir, everything goes awfully well!
